### PR TITLE
1.0.5

### DIFF
--- a/flashrnn/autotune/constrint.py
+++ b/flashrnn/autotune/constrint.py
@@ -53,6 +53,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from functools import lru_cache, wraps
 from typing import Iterable, Optional, Sequence, Union
+from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1931,7 +1932,7 @@ class ValueRefinement:
 
 
 @cache_decorator(
-    os.getenv("CONSTRINT_CACHE_DIR", os.getenv("HOME") + "/.cache/constrint")
+    os.getenv("CONSTRINT_CACHE_DIR", str(Path.home() / ".cache" / "constrint"))
 )
 def solve_constrint(
     constr: Constraint,

--- a/flashrnn/flashrnn/cuda_init.py
+++ b/flashrnn/flashrnn/cuda_init.py
@@ -4,18 +4,47 @@
 import os
 from typing import Sequence, Union
 import logging
+import functools
+import subprocess
+import sys
+from packaging.version import Version
+import re
 
 import time
 import random
 
 import torch
 from torch.utils.cpp_extension import load as _load
+from torch.utils.cpp_extension import  _find_cuda_home 
+
 
 # print("INCLUDE:", torch.utils.cpp_extension.include_paths(cuda=True))
 # print("C++ compat", torch.utils.cpp_extension.check_compiler_abi_compatibility("g++"))
 # print("C compat", torch.utils.cpp_extension.check_compiler_abi_compatibility("gcc"))
 
 LOGGER = logging.getLogger(__name__)
+CUDA_HOME = _find_cuda_home()
+IS_WINDOWS = sys.platform == 'win32'
+IS_MACOS = sys.platform.startswith('darwin')
+SUBPROCESS_DECODE_ARGS = ('oem',) if IS_WINDOWS else ()
+
+@functools.cache
+def get_cuda_version() -> Version | None:
+    try:
+        nvcc = os.path.join(CUDA_HOME, 'bin', 'nvcc.exe' if IS_WINDOWS else 'nvcc')
+        cuda_version_str = subprocess.check_output([nvcc, '--version']).strip().decode(*SUBPROCESS_DECODE_ARGS)
+        cuda_version = re.search(r'release (\d+[.]\d+)', cuda_version_str)
+
+        if cuda_version is None:
+            return
+        cuda_str_version = cuda_version.group(1)
+        cuda_version = Version(cuda_str_version)
+        return cuda_version
+    except (RuntimeError, FileNotFoundError, subprocess.CalledProcessError) as e:
+        # raise RuntimeError(
+        #         "Could not determine CUDA version."
+        #     ) from e
+        return 
 
 
 def defines_to_cflags(
@@ -124,6 +153,11 @@ def load(*, name, sources, extra_cflags=(), extra_cuda_cflags=(), **kwargs):
             *extra_cuda_cflags,
         ],
     }
+
+    cuda_version = get_cuda_version()
+    if cuda_version is not None and cuda_version >= Version("12.8"):
+        myargs['extra_cuda_cflags'].append("-static-global-template-stub=false")
+
     LOGGER.info("Kernel compilation arguments", myargs)
     myargs.update(**kwargs)
     # add random waiting time to minimize deadlocks because of badly managed multicompile of pytorch ext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flashrnn"
-version = "1.0.4"
+version = "1.0.5"
 authors = [
   { name="Korbinian Pöppel", email="korbinian.poeppel@nx-ai.com" },
   { name="Maximilian Beck", email="maximilian.beck@nx-ai.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "torch",
     "einops",
-    "triton",
+    "triton; sys_platform == 'linux'",
     "ninja"
 ]
 


### PR DESCRIPTION
## Fixes

1. Fixes sLSTM kernel compilation 

**Before:** compilation of the sLSTM kernel failed on the CUDA version >= 13.0, because of the [-static-global-template-stub](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#static-global-template-stub-true-false-static-global-template-stub) flag, which defaults to `true`. For the [CUDA version 12.8](https://docs.nvidia.com/cuda/archive/12.8.0/cuda-compiler-driver-nvcc/index.html#static-global-template-stub-true-false-static-global-template-stub) the exact same flag defaults to `false` (which is what we need)

**Fix:** this flag was introduced only starting from the CUDA version 12.8 and simply inserting it would lead to an error (see [example](https://github.com/flashinfer-ai/flashinfer/issues/1532))

In order to fix the issue the `_find_cuda_home` (from pytorch `cpp_extensions`) as well as `get_cuda_version` were introduced. The flag `-static-global-template-stub=false` is inserted to the `args`, only if CUDA version is >= 12.8 and CUDA path is found.

**Important:** Major CUDA Toolkit version used for compilation should match with the CUDA version used by the PyTorch wheel. Mismatched versions (e.g., PyTorch cu128 with CUDA Toolkit 13.0)  lead to build issues,

2. Triton installation

**Before:** `flashrnn` attempts to install `triton` unconditionally even for windows and macos.

**Fix:**installs triton only for linux.

3. Home path:

**Before:** [constrint.py](https://github.com/NX-AI/flashrnn/compare/main...1.0.5#diff-c7760faed668c994ebafbb33c18b49a72be507c15bf73abe9fe8bb4a05ee4992) path failed on windows

**Fix:** Path.home() should fix home path for windows (still to be tested)

## How to test:


### main.py script for testing:

```
import os

#for cuda home
# os.environ["CUDA_HOME"] = "/home/dan_yef/.local/cuda-nvcc-12.8"
os.environ["CUDA_HOME"] = "/usr/local/cuda-13.0"
# os.environ["CUDA_HOME"] = "/usr/local/cuda-13.3"

#for nvcc
os.environ["PATH"] = f"{os.environ['CUDA_HOME']}/bin:" + os.environ["PATH"]

#cuda libraries
ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
os.environ["LD_LIBRARY_PATH"] = (
    f"{os.environ['CUDA_HOME']}/lib64"
    + (":" + ld_library_path if ld_library_path else "")
)


import torch
from tirex2 import TimeseriesType, load_model

# load model
model = load_model("NX-AI/TiRex-2", device="cuda")


context = torch.sin(torch.arange(128).float() / 8)
ts = TimeseriesType(target=context.unsqueeze(0), past_covariates=None, future_covariates=None)

forecast = model.forecast([ts], prediction_length=32, output_type="numpy")[0]
print(forecast)
```

### MacOS:
```

# 1. Go to the root
cd /your/root/folder

# 2. venv on Python 3.11
python3.11 -m venv .venv
source .venv/bin/activate
python -m pip install -U pip

# 3. Install flashrnn from source
git -C flashrnn checkout 1.0.5   
pip install -e ./flashrnn

# 4. Install tirex-2 from source
pip install -e ./tirex-2

# 5. HF_TOKEN
export HF_TOKEN=hf_xxxxxxxxxxxxxxxxx     

# 6. Run main.py from a subfolder 
mkdir -p run
cd run
python main.py
```

### Linux:

```
# 0. Go to the repo root

# 1. Initialize conda for the current shell
source /home/dan_yef/miniconda3/etc/profile.d/conda.sh

# 2. Conda Env
conda create -y -n tirex311 python=3.11
conda activate tirex311

# 3. Install flashrnn
git -C flashrnn checkout 1.0.5   
pip install -e ./flashrnn

# 4. Install tirex-2 from source
# for cuda 13.0 and above relax torch requirement in pyproject.toml
#  "torch>=2.8"
pip install -e ./tirex-2

# 5. Check PyTorch version (especially cuda wheel):
python -c "import torch; print(torch.__version__)"

# 6. HF_TOKEN
export HF_TOKEN=hf_xxxxxxxxxxxxxxxxx   

# 7. Run main.py from a subfolder 
mkdir -p run
cd run
python main.py

# 8. Deactivate
conda deactivate

# 9. Remove Env
conda env remove -n tirex311
```

