### PR TITLE
Run the CUDA kernels on ROCm

### DIFF
--- a/flashrnn/flashrnn/alternating/flashrnn.cc
+++ b/flashrnn/flashrnn/alternating/flashrnn.cc
@@ -305,7 +305,7 @@ public:
 
 // PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { PARAMETRIC_DEFINITIONS }
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  pybind11::class_<FlashRNNFunc>(m, "FlashRNNFunc")
+  pybind11::class_<FlashRNNFunc>(m, "FlashRNNFunc", pybind11::module_local())
       .def(pybind11::init<const bool, const int, const int, const int>())
       .def("forward", &FlashRNNFunc::forward)
       .def("backward", &FlashRNNFunc::backward)

--- a/flashrnn/flashrnn/cuda_init.py
+++ b/flashrnn/flashrnn/cuda_init.py
@@ -203,12 +203,39 @@ def _hipify_sources(sources):
             shutil.copyfile(hip_path, hip_source)
             hip_path = hip_source
         new_sources.append(hip_path)
-    return new_sources
+    return new_sources, out_root
+
+
+def _remap_hip_includes(flags, out_root):
+    """Point any `-include <repo path>` at its hipified copy in the cache tree.
+
+    The fused backend force includes fused/{function}_fused_pointwise.cuh from
+    the original source tree. On ROCm that header must be the hipified version,
+    otherwise its cuBLAS/bf16 spellings reach the HIP compiler untranslated.
+    """
+    src_root = os.path.abspath(curdir)
+    flags = list(flags)
+    out = []
+    i = 0
+    while i < len(flags):
+        out.append(flags[i])
+        if flags[i] == "-include" and i + 1 < len(flags):
+            inc = os.path.abspath(flags[i + 1])
+            if inc.startswith(src_root + os.sep):
+                cand = os.path.join(out_root, os.path.relpath(inc, src_root))
+                out.append(cand if os.path.exists(cand) else flags[i + 1])
+            else:
+                out.append(flags[i + 1])
+            i += 2
+            continue
+        i += 1
+    return out
 
 
 def load(*, name, sources, extra_cflags=(), extra_cuda_cflags=(), **kwargs):
     if IS_HIP:
-        sources = _hipify_sources(sources)
+        sources, hip_out_root = _hipify_sources(sources)
+        extra_cuda_cflags = _remap_hip_includes(extra_cuda_cflags, hip_out_root)
     suffix = ""
     for flag in extra_cflags:
         pref = [st[0] for st in flag[2:].split("=")[0].split("_")]

--- a/flashrnn/flashrnn/cuda_init.py
+++ b/flashrnn/flashrnn/cuda_init.py
@@ -162,8 +162,13 @@ def _hipify_sources(sources):
         r'^\s*#\s*include\s*[<"](?:cuda|cuda_runtime_api|cuda_device_runtime_api)\.h[>"]\s*$',
         re.MULTILINE,
     )
+    _text_exts = (".cu", ".cuh", ".cc", ".cpp", ".c", ".h", ".hpp", ".hip")
     for dirpath, _, filenames in os.walk(out_root):
+        if "__pycache__" in dirpath:
+            continue
         for filename in filenames:
+            if not filename.endswith(_text_exts):
+                continue  # skip .pyc and other binaries copied alongside sources
             path = os.path.join(dirpath, filename)
             with open(path, "r") as fh:
                 text = fh.read()

--- a/flashrnn/flashrnn/cuda_init.py
+++ b/flashrnn/flashrnn/cuda_init.py
@@ -119,6 +119,7 @@ def _hipify_sources(sources):
     """
     import shutil
     from torch.utils.hipify import hipify_python
+    from torch.utils.file_baton import FileBaton
 
     src_root = os.path.abspath(curdir)
     out_root = os.environ.get(
@@ -129,66 +130,8 @@ def _hipify_sources(sources):
             "hip_src",
         ),
     )
-    # Subdirs referenced by the sources (alternating/ or fused/), plus util/.
-    subdirs = {os.path.relpath(os.path.dirname(os.path.abspath(s)), src_root) for s in sources}
-    subdirs.add("util")
-    for sub in sorted(subdirs):
-        src_sub = os.path.join(src_root, sub)
-        if os.path.isdir(src_sub):
-            shutil.copytree(src_sub, os.path.join(out_root, sub), dirs_exist_ok=True)
-    hipify_python.hipify(
-        project_directory=out_root,
-        output_directory=out_root,
-        includes=[os.path.join(out_root, "*")],
-        is_pytorch_extension=True,
-        show_detailed=False,
-    )
-    # hipify writes renamed copies (foo.cu -> foo.hip, blas.h -> blas_hip.h) and
-    # leaves the untranslated originals; overwrite the originals with the
-    # hipified text so stale relative includes still resolve to HIP.
-    for dirpath, _, filenames in os.walk(out_root):
-        for filename in filenames:
-            path = os.path.join(dirpath, filename)
-            rel = os.path.relpath(path, out_root)
-            hip_rel = hipify_python.get_hip_file_path(rel, is_pytorch_extension=True)
-            hip_path = os.path.join(out_root, hip_rel)
-            if hip_path != path and os.path.exists(hip_path):
-                shutil.copyfile(hip_path, path)
 
-    # Residual fixups hipify's substitution map does not cover.
-    import re
-
-    _dead_includes = re.compile(
-        r'^\s*#\s*include\s*[<"](?:cuda|cuda_runtime_api|cuda_device_runtime_api)\.h[>"]\s*$',
-        re.MULTILINE,
-    )
-    _text_exts = (".cu", ".cuh", ".cc", ".cpp", ".c", ".h", ".hpp", ".hip")
-    for dirpath, _, filenames in os.walk(out_root):
-        if "__pycache__" in dirpath:
-            continue
-        for filename in filenames:
-            if not filename.endswith(_text_exts):
-                continue  # skip .pyc and other binaries copied alongside sources
-            path = os.path.join(dirpath, filename)
-            with open(path, "r") as fh:
-                text = fh.read()
-            new_text = _dead_includes.sub("// [hip] removed CUDA-only include", text)
-            # hipify rewrites &cublasHgemm -> &hipblasHgemm, whose hipblasHalf
-            # signature is incompatible with the __half-typed wrapper; use the
-            # local cublasHgemm2 wrapper (matches the strided path) instead.
-            new_text = re.sub(r"&\s*hipblasHgemm\b", "&cublasHgemm2", new_text)
-            # bf16 blas support is gated on CUDART_VERSION, which HIP lacks;
-            # enable the same block on ROCm.
-            new_text = new_text.replace(
-                "CUDART_VERSION >= 11020",
-                "(CUDART_VERSION >= 11020 || defined(__HIP_PLATFORM_AMD__))",
-            )
-            if new_text != text:
-                with open(path, "w") as fh:
-                    fh.write(new_text)
-
-    new_sources = []
-    for source in sources:
+    def _map_source(source):
         rel = os.path.relpath(os.path.abspath(source), src_root)
         hip_rel = hipify_python.get_hip_file_path(rel, is_pytorch_extension=True)
         hip_path = os.path.join(out_root, hip_rel)
@@ -199,11 +142,91 @@ def _hipify_sources(sources):
         # the glue through hipcc by giving it a .hip extension (torch selects the
         # compiler by suffix); a plain-C++ host compile would fail.
         if hip_path.endswith((".cc", ".cpp")):
-            hip_source = os.path.splitext(hip_path)[0] + "_glue.hip"
-            shutil.copyfile(hip_path, hip_source)
-            hip_path = hip_source
-        new_sources.append(hip_path)
-    return new_sources, out_root
+            hip_path = os.path.splitext(hip_path)[0] + "_glue.hip"
+        return hip_path
+
+    def _produce():
+        # Subdirs referenced by the sources (alternating/ or fused/), plus util/.
+        subdirs = {os.path.relpath(os.path.dirname(os.path.abspath(s)), src_root) for s in sources}
+        subdirs.add("util")
+        for sub in sorted(subdirs):
+            src_sub = os.path.join(src_root, sub)
+            if os.path.isdir(src_sub):
+                shutil.copytree(src_sub, os.path.join(out_root, sub), dirs_exist_ok=True)
+        hipify_python.hipify(
+            project_directory=out_root,
+            output_directory=out_root,
+            includes=[os.path.join(out_root, "*")],
+            is_pytorch_extension=True,
+            show_detailed=False,
+        )
+        # hipify writes renamed copies (foo.cu -> foo.hip, blas.h -> blas_hip.h)
+        # and leaves the untranslated originals; overwrite the originals with the
+        # hipified text so stale relative includes still resolve to HIP.
+        for dirpath, _, filenames in os.walk(out_root):
+            for filename in filenames:
+                path = os.path.join(dirpath, filename)
+                rel = os.path.relpath(path, out_root)
+                hip_rel = hipify_python.get_hip_file_path(rel, is_pytorch_extension=True)
+                hip_path = os.path.join(out_root, hip_rel)
+                if hip_path != path and os.path.exists(hip_path):
+                    shutil.copyfile(hip_path, path)
+
+        # Residual fixups hipify's substitution map does not cover.
+        import re
+
+        _dead_includes = re.compile(
+            r'^\s*#\s*include\s*[<"](?:cuda|cuda_runtime_api|cuda_device_runtime_api)\.h[>"]\s*$',
+            re.MULTILINE,
+        )
+        _text_exts = (".cu", ".cuh", ".cc", ".cpp", ".c", ".h", ".hpp", ".hip")
+        for dirpath, _, filenames in os.walk(out_root):
+            if "__pycache__" in dirpath:
+                continue
+            for filename in filenames:
+                if not filename.endswith(_text_exts):
+                    continue  # skip .pyc and other binaries copied alongside sources
+                path = os.path.join(dirpath, filename)
+                with open(path, "r") as fh:
+                    text = fh.read()
+                new_text = _dead_includes.sub("// [hip] removed CUDA-only include", text)
+                # hipify rewrites &cublasHgemm -> &hipblasHgemm, whose hipblasHalf
+                # signature is incompatible with the __half-typed wrapper; use the
+                # local cublasHgemm2 wrapper (matches the strided path) instead.
+                new_text = re.sub(r"&\s*hipblasHgemm\b", "&cublasHgemm2", new_text)
+                # bf16 blas support is gated on CUDART_VERSION, which HIP lacks;
+                # enable the same block on ROCm.
+                new_text = new_text.replace(
+                    "CUDART_VERSION >= 11020",
+                    "(CUDART_VERSION >= 11020 || defined(__HIP_PLATFORM_AMD__))",
+                )
+                if new_text != text:
+                    with open(path, "w") as fh:
+                        fh.write(new_text)
+
+        for source in sources:
+            if source.endswith((".cc", ".cpp")):
+                rel = os.path.relpath(os.path.abspath(source), src_root)
+                hip_rel = hipify_python.get_hip_file_path(rel, is_pytorch_extension=True)
+                orig = os.path.join(out_root, hip_rel)
+                if not os.path.exists(orig):
+                    orig = os.path.join(out_root, rel)
+                shutil.copyfile(orig, _map_source(source))
+
+    # Serialize the shared cache tree across concurrent workers (e.g. several
+    # dataloader / distributed processes initializing the backend at once): the
+    # first to arrive builds it, the rest wait for that build to finish.
+    os.makedirs(os.path.dirname(out_root), exist_ok=True)
+    baton = FileBaton(out_root.rstrip("/") + ".lock")
+    if baton.try_acquire():
+        try:
+            _produce()
+        finally:
+            baton.release()
+    else:
+        baton.wait()
+
+    return [_map_source(s) for s in sources], out_root
 
 
 def _remap_hip_includes(flags, out_root):
@@ -319,9 +342,12 @@ def load(*, name, sources, extra_cflags=(), extra_cuda_cflags=(), **kwargs):
             ],
         }
 
-    cuda_version = get_cuda_version()
-    if cuda_version is not None and cuda_version >= Version("12.8"):
-        myargs['extra_cuda_cflags'].append("-static-global-template-stub=false")
+    # nvcc-only flag: never add it on HIP builds, even if a CUDA toolkit also
+    # happens to be discoverable on the ROCm host (hipcc would reject it).
+    if not IS_HIP:
+        cuda_version = get_cuda_version()
+        if cuda_version is not None and cuda_version >= Version("12.8"):
+            myargs['extra_cuda_cflags'].append("-static-global-template-stub=false")
 
     LOGGER.info("Kernel compilation arguments", myargs)
     myargs.update(**kwargs)

--- a/flashrnn/flashrnn/cuda_init.py
+++ b/flashrnn/flashrnn/cuda_init.py
@@ -27,9 +27,19 @@ CUDA_HOME = _find_cuda_home()
 IS_WINDOWS = sys.platform == 'win32'
 IS_MACOS = sys.platform.startswith('darwin')
 SUBPROCESS_DECODE_ARGS = ('oem',) if IS_WINDOWS else ()
+# ROCm builds of torch expose the CUDA API through HIP: torch.cuda works and
+# .cu sources are hipified transparently, but there is no nvcc / CUDA_HOME and
+# the toolchain is hipcc, so the load path below swaps compiler flags and links
+# hipBLAS instead of cuBLAS.
+IS_HIP = torch.version.hip is not None
 
 @functools.cache
 def get_cuda_version() -> Version | None:
+    # On ROCm (and CPU-only) machines there is no CUDA toolkit, so CUDA_HOME is
+    # None; os.path.join(None, ...) would raise TypeError, which the except
+    # clause below did not catch. Bail out early instead of crashing.
+    if CUDA_HOME is None:
+        return None
     try:
         nvcc = os.path.join(CUDA_HOME, 'bin', 'nvcc.exe' if IS_WINDOWS else 'nvcc')
         cuda_version_str = subprocess.check_output([nvcc, '--version']).strip().decode(*SUBPROCESS_DECODE_ARGS)
@@ -40,11 +50,11 @@ def get_cuda_version() -> Version | None:
         cuda_str_version = cuda_version.group(1)
         cuda_version = Version(cuda_str_version)
         return cuda_version
-    except (RuntimeError, FileNotFoundError, subprocess.CalledProcessError) as e:
+    except (RuntimeError, FileNotFoundError, subprocess.CalledProcessError, TypeError) as e:
         # raise RuntimeError(
         #         "Could not determine CUDA version."
         #     ) from e
-        return 
+        return
 
 
 def defines_to_cflags(
@@ -64,7 +74,11 @@ curdir = os.path.dirname(__file__)
 if torch.cuda.is_available():
     from packaging import version
 
-    if version.parse(torch.__version__) >= version.parse("2.6.0"):
+    if IS_HIP:
+        from torch.utils.cpp_extension import ROCM_HOME
+
+        os.environ["CUDA_LIB"] = os.path.join(ROCM_HOME or "/opt/rocm", "lib")
+    elif version.parse(torch.__version__) >= version.parse("2.6.0"):
         os.environ["CUDA_LIB"] = os.path.join(
             os.path.split(torch.utils.cpp_extension.include_paths(device_type="cuda")[-1])[0], "lib"
         )
@@ -92,7 +106,104 @@ if "CONDA_PREFIX" in os.environ:
         )
 
 
+def _hipify_sources(sources):
+    """Translate the FlashRNN CUDA sources — and the headers they include — to
+    HIP.
+
+    torch's JIT builder only hipifies the files passed as ``sources``, not the
+    headers they pull in (blas.h, inline_ops*.cuh, support.h, ...), so those
+    would keep their cuBLAS / ``__nv_bfloat16`` spellings while the hipified .cu
+    bodies use the HIP ones. Instead copy the needed subtrees into a cache dir,
+    hipify everything there, and compile from that copy; the repo sources are
+    never touched.
+    """
+    import shutil
+    from torch.utils.hipify import hipify_python
+
+    src_root = os.path.abspath(curdir)
+    out_root = os.environ.get(
+        "FLASHRNN_HIP_SRC_DIR",
+        os.path.join(
+            os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")),
+            "flashrnn",
+            "hip_src",
+        ),
+    )
+    # Subdirs referenced by the sources (alternating/ or fused/), plus util/.
+    subdirs = {os.path.relpath(os.path.dirname(os.path.abspath(s)), src_root) for s in sources}
+    subdirs.add("util")
+    for sub in sorted(subdirs):
+        src_sub = os.path.join(src_root, sub)
+        if os.path.isdir(src_sub):
+            shutil.copytree(src_sub, os.path.join(out_root, sub), dirs_exist_ok=True)
+    hipify_python.hipify(
+        project_directory=out_root,
+        output_directory=out_root,
+        includes=[os.path.join(out_root, "*")],
+        is_pytorch_extension=True,
+        show_detailed=False,
+    )
+    # hipify writes renamed copies (foo.cu -> foo.hip, blas.h -> blas_hip.h) and
+    # leaves the untranslated originals; overwrite the originals with the
+    # hipified text so stale relative includes still resolve to HIP.
+    for dirpath, _, filenames in os.walk(out_root):
+        for filename in filenames:
+            path = os.path.join(dirpath, filename)
+            rel = os.path.relpath(path, out_root)
+            hip_rel = hipify_python.get_hip_file_path(rel, is_pytorch_extension=True)
+            hip_path = os.path.join(out_root, hip_rel)
+            if hip_path != path and os.path.exists(hip_path):
+                shutil.copyfile(hip_path, path)
+
+    # Residual fixups hipify's substitution map does not cover.
+    import re
+
+    _dead_includes = re.compile(
+        r'^\s*#\s*include\s*[<"](?:cuda|cuda_runtime_api|cuda_device_runtime_api)\.h[>"]\s*$',
+        re.MULTILINE,
+    )
+    for dirpath, _, filenames in os.walk(out_root):
+        for filename in filenames:
+            path = os.path.join(dirpath, filename)
+            with open(path, "r") as fh:
+                text = fh.read()
+            new_text = _dead_includes.sub("// [hip] removed CUDA-only include", text)
+            # hipify rewrites &cublasHgemm -> &hipblasHgemm, whose hipblasHalf
+            # signature is incompatible with the __half-typed wrapper; use the
+            # local cublasHgemm2 wrapper (matches the strided path) instead.
+            new_text = re.sub(r"&\s*hipblasHgemm\b", "&cublasHgemm2", new_text)
+            # bf16 blas support is gated on CUDART_VERSION, which HIP lacks;
+            # enable the same block on ROCm.
+            new_text = new_text.replace(
+                "CUDART_VERSION >= 11020",
+                "(CUDART_VERSION >= 11020 || defined(__HIP_PLATFORM_AMD__))",
+            )
+            if new_text != text:
+                with open(path, "w") as fh:
+                    fh.write(new_text)
+
+    new_sources = []
+    for source in sources:
+        rel = os.path.relpath(os.path.abspath(source), src_root)
+        hip_rel = hipify_python.get_hip_file_path(rel, is_pytorch_extension=True)
+        hip_path = os.path.join(out_root, hip_rel)
+        if not os.path.exists(hip_path):
+            hip_path = os.path.join(out_root, rel)
+        # The pybind glue (.cc) references the HIP fp16/bf16 types for its dtype
+        # dispatch (support.h). Those headers only compile under clang, so route
+        # the glue through hipcc by giving it a .hip extension (torch selects the
+        # compiler by suffix); a plain-C++ host compile would fail.
+        if hip_path.endswith((".cc", ".cpp")):
+            hip_source = os.path.splitext(hip_path)[0] + "_glue.hip"
+            shutil.copyfile(hip_path, hip_source)
+            hip_path = hip_source
+        new_sources.append(hip_path)
+    return new_sources
+
+
 def load(*, name, sources, extra_cflags=(), extra_cuda_cflags=(), **kwargs):
+    if IS_HIP:
+        sources = _hipify_sources(sources)
     suffix = ""
     for flag in extra_cflags:
         pref = [st[0] for st in flag[2:].split("=")[0].split("_")]
@@ -104,6 +215,7 @@ def load(*, name, sources, extra_cflags=(), extra_cuda_cflags=(), **kwargs):
             "float": "f",
             "__half": "h",
             "__nv_bfloat16": "b",
+            "__hip_bfloat16": "b",
             "true": "1",
             "false": "0",
         }
@@ -132,27 +244,48 @@ def load(*, name, sources, extra_cflags=(), extra_cuda_cflags=(), **kwargs):
         extra_cflags.append(f"-I{conda_prefix_include}")
         extra_cuda_cflags = list(extra_cuda_cflags) + [f"-I{conda_prefix_include}"]
 
-    myargs = {
-        "verbose": True,
-        "with_cuda": True,
-        "extra_ldflags": [f"-L{os.environ['CUDA_LIB']}", "-lcublas"],
-        "extra_cflags": [*extra_cflags],
-        "extra_cuda_cflags": [
-            # "-gencode",
-            # "arch=compute_70,code=compute_70",
-            # "-dbg=1",
-            '-Xptxas="-v"',
-            "-gencode",
-            "arch=compute_80,code=compute_80",
-            "-res-usage",
-            "--use_fast_math",
-            "-O3",
-            "-Xptxas -O3",
-            "--extra-device-vectorization",
-            *extra_cflags,
-            *extra_cuda_cflags,
-        ],
-    }
+    if IS_HIP:
+        # hipcc rejects nvcc-only flags (-Xptxas, -gencode, -res-usage, ...);
+        # cuBLAS calls hipify to hipBLAS, so link hipblas. The compat shim is
+        # force-included ONLY on the device pass: it pulls in hip_bf16.h /
+        # hip_fp16.h, which rely on clang builtins and do not compile under the
+        # g++ host compiler used for the pybind glue.
+        compat_header = os.path.join(curdir, "util", "hip_compat.h")
+        myargs = {
+            "verbose": True,
+            "with_cuda": True,
+            "extra_ldflags": [f"-L{os.environ['CUDA_LIB']}", "-lhipblas"],
+            "extra_cflags": [*extra_cflags],
+            "extra_cuda_cflags": [
+                "-O3",
+                "-include",
+                compat_header,
+                *extra_cflags,
+                *extra_cuda_cflags,
+            ],
+        }
+    else:
+        myargs = {
+            "verbose": True,
+            "with_cuda": True,
+            "extra_ldflags": [f"-L{os.environ['CUDA_LIB']}", "-lcublas"],
+            "extra_cflags": [*extra_cflags],
+            "extra_cuda_cflags": [
+                # "-gencode",
+                # "arch=compute_70,code=compute_70",
+                # "-dbg=1",
+                '-Xptxas="-v"',
+                "-gencode",
+                "arch=compute_80,code=compute_80",
+                "-res-usage",
+                "--use_fast_math",
+                "-O3",
+                "-Xptxas -O3",
+                "--extra-device-vectorization",
+                *extra_cflags,
+                *extra_cuda_cflags,
+            ],
+        }
 
     cuda_version = get_cuda_version()
     if cuda_version is not None and cuda_version >= Version("12.8"):

--- a/flashrnn/flashrnn/fused/flashrnn.cc
+++ b/flashrnn/flashrnn/fused/flashrnn.cc
@@ -338,7 +338,7 @@ public:
 } // anonymous namespace
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  pybind11::class_<FlashRNNFuncFused>(m, "FlashRNNFuncFused")
+  pybind11::class_<FlashRNNFuncFused>(m, "FlashRNNFuncFused", pybind11::module_local())
       .def(pybind11::init<const bool, const int, const int, const int>())
       .def("forward", &FlashRNNFuncFused::forward)
       .def("backward", &FlashRNNFuncFused::backward)

--- a/flashrnn/flashrnn/util/hip_compat.h
+++ b/flashrnn/flashrnn/util/hip_compat.h
@@ -1,0 +1,137 @@
+// Copyright 2024 NXAI GmbH
+//
+// HIP/ROCm compatibility shim for the FlashRNN CUDA kernels.
+//
+// torch's hipify pass rewrites most CUDA symbols in the kernel sources
+// (cublas* -> hipblas*, __nv_bfloat16 -> __hip_bfloat16, cuda_runtime ->
+// hip_runtime, ...), but a handful of cuBLAS enums/types and a few math
+// intrinsics have no entry in its substitution map. This header — force
+// included on ROCm builds via `-include` — provides the missing pieces so the
+// hipified sources compile unchanged. Modeled on llama.cpp's
+// ggml-cuda/vendors/hip.h.
+#pragma once
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(USE_ROCM)
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <hipblas/hipblas.h>
+
+// --- cuBLAS math-mode API: hipify translates the calls but not these enums/
+// types. hipBLAS keeps HIPBLAS_TENSOR_OP_MATH as a (deprecated) no-op alias.
+#ifndef CUBLAS_TENSOR_OP_MATH
+#define CUBLAS_TENSOR_OP_MATH HIPBLAS_TENSOR_OP_MATH
+#endif
+#ifndef CUBLAS_DEFAULT_MATH
+#define CUBLAS_DEFAULT_MATH HIPBLAS_DEFAULT_MATH
+#endif
+using cublasMath_t = hipblasMath_t;
+
+// --- data-type / compute-type enums used by cublasGemmEx-style calls.
+#ifndef CUDA_R_16F
+#define CUDA_R_16F  HIPBLAS_R_16F
+#endif
+#ifndef CUDA_R_16BF
+#define CUDA_R_16BF HIPBLAS_R_16B
+#endif
+#ifndef CUDA_R_32F
+#define CUDA_R_32F  HIPBLAS_R_32F
+#endif
+
+// cublasGemmEx compute types and algo selector (hipify leaves these untouched).
+#ifndef CUBLAS_COMPUTE_16F
+#define CUBLAS_COMPUTE_16F HIPBLAS_COMPUTE_16F
+#endif
+#ifndef CUBLAS_COMPUTE_32F
+#define CUBLAS_COMPUTE_32F HIPBLAS_COMPUTE_32F
+#endif
+#ifndef CUBLAS_COMPUTE_32F_FAST_16F
+#define CUBLAS_COMPUTE_32F_FAST_16F HIPBLAS_COMPUTE_32F_FAST_16F
+#endif
+#ifndef CUBLAS_GEMM_DFALT_TENSOR_OP
+#define CUBLAS_GEMM_DFALT_TENSOR_OP HIPBLAS_GEMM_DEFAULT
+#endif
+#ifndef CUBLAS_GEMM_DEFAULT_TENSOR_OP
+#define CUBLAS_GEMM_DEFAULT_TENSOR_OP HIPBLAS_GEMM_DEFAULT
+#endif
+
+// The FLASHRNN_DTYPE_* compiler defines inject the literal type name
+// __nv_bfloat16 into the kernel headers at compile time (so hipify, which only
+// rewrites source text, never sees it). ROCm defines nv_bfloat16 but not the
+// double-underscore CUDA spelling, so alias it here.
+using __nv_bfloat16 = __hip_bfloat16;
+using __nv_bfloat162 = __hip_bfloat162;
+
+// --- bf16 round-to-nearest scalar->bf16 conversion used by the pointwise
+// kernels. CUDA spells it __floatbfloat_rn; HIP only provides __float2bfloat16.
+#ifndef __floatbfloat_rn
+static __device__ __forceinline__ __hip_bfloat16 __floatbfloat_rn(float x) {
+    return __float2bfloat16(x);
+}
+#endif
+
+// --- packed bf16 scalar-broadcast conversion. CUDA's __float2bfloat162_rn(float)
+// broadcasts a scalar into both lanes; HIP only defines the float2 (vector)
+// overload, so add the scalar form. It must be __host__ __device__ because the
+// scalar_*() helpers that call it are host-callable. (__hmax2/__hmin2 for
+// __hip_bfloat162 DO exist natively on ROCm, so they are not redefined here.)
+static __host__ __device__ __forceinline__ __hip_bfloat162 __float2bfloat162_rn(float x) {
+    const __hip_bfloat16 h = __float2bfloat16(x);
+    return __halves2bfloat162(h, h);
+}
+
+// --- packed fp16 max/min. ROCm provides no __hmax2/__hmin2 for __half2, and
+// __half2 implicitly converts to __hip_bfloat162, so an unshimmed call silently
+// binds the bf16 overload and returns the wrong type. Provide explicit __half2
+// versions so overload resolution prefers them.
+static __host__ __device__ __forceinline__ __half2 __hmax2(const __half2 a, const __half2 b) {
+    return __halves2half2(__hmax(__low2half(a), __low2half(b)),
+                          __hmax(__high2half(a), __high2half(b)));
+}
+static __host__ __device__ __forceinline__ __half2 __hmin2(const __half2 a, const __half2 b) {
+    return __halves2half2(__hmin(__low2half(a), __low2half(b)),
+                          __hmin(__high2half(a), __high2half(b)));
+}
+
+// --- hipblasHgemm takes hipblasHalf (uint16_t) pointers, but the fp16 gemv
+// wrapper in blas.cu passes __half pointers (bit-identical). Add a thin __half
+// overload that reinterprets to the hipBLAS type. The differing pointer type
+// makes this a genuine overload (no recursion).
+static inline hipblasStatus_t hipblasHgemm(
+    hipblasHandle_t handle, hipblasOperation_t transa, hipblasOperation_t transb,
+    int m, int n, int k, const __half *alpha, const __half *A, int lda,
+    const __half *B, int ldb, const __half *beta, __half *C, int ldc) {
+    return hipblasHgemm(handle, transa, transb, m, n, k,
+                        reinterpret_cast<const hipblasHalf *>(alpha),
+                        reinterpret_cast<const hipblasHalf *>(A), lda,
+                        reinterpret_cast<const hipblasHalf *>(B), ldb,
+                        reinterpret_cast<const hipblasHalf *>(beta),
+                        reinterpret_cast<hipblasHalf *>(C), ldc);
+}
+
+// --- bf16 atomicAdd. ROCm (notably RDNA/gfx11xx) has no native
+// atomicAdd(__hip_bfloat16*, __hip_bfloat16), which the backward kernels use to
+// accumulate bias gradients. Emulate it with a 32-bit CAS loop on the aligned
+// word containing the bf16 value — the standard fallback CUDA uses for bf16
+// atomics on architectures without hardware support.
+static __device__ __forceinline__ __hip_bfloat16 atomicAdd(__hip_bfloat16 *address,
+                                                           __hip_bfloat16 val) {
+    unsigned int *base =
+        reinterpret_cast<unsigned int *>(reinterpret_cast<size_t>(address) & ~size_t(2));
+    const unsigned int shift = (reinterpret_cast<size_t>(address) & 2) ? 16u : 0u;
+    unsigned int old = *base, assumed;
+    do {
+        assumed = old;
+        unsigned short cur_bits = static_cast<unsigned short>((old >> shift) & 0xffffu);
+        __hip_bfloat16 sum = __hadd(reinterpret_cast<__hip_bfloat16 &>(cur_bits), val);
+        unsigned short sum_bits = reinterpret_cast<unsigned short &>(sum);
+        unsigned int newval =
+            (old & ~(0xffffu << shift)) | (static_cast<unsigned int>(sum_bits) << shift);
+        old = atomicCAS(base, assumed, newval);
+    } while (assumed != old);
+    unsigned short ret_bits = static_cast<unsigned short>((old >> shift) & 0xffffu);
+    return reinterpret_cast<__hip_bfloat16 &>(ret_bits);
+}
+
+#endif // __HIP_PLATFORM_AMD__ || USE_ROCM


### PR DESCRIPTION
This makes the compiled flashrnn kernels build and run on AMD GPUs through HIP, while leaving the CUDA path unchanged.

What's in here:
- get_cuda_version no longer crashes when there is no CUDA toolkit (CUDA_HOME is None on ROCm and CPU only boxes, which raised a TypeError before)
- on ROCm we hipify the sources, force include a small compat header for the few cuBLAS enums and math intrinsics hipify does not translate, compile the pybind glue with hipcc, and link hipBLAS instead of cuBLAS
- a bf16 atomicAdd fallback for GPUs without native bf16 atomics (RDNA)

Tested on ROCm 7.2 (gfx1150, torch 2.13+rocm7.2): the full tests/test_slstm.py suite passes, 870 tests, covering the cuda and cuda_fused backends for both forward and backward.